### PR TITLE
Bugfix/serial rw fixes (#150)

### DIFF
--- a/include/Communication/BTSerialCommunicationManager.h
+++ b/include/Communication/BTSerialCommunicationManager.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <Winsock2.h>
+#include <WinSock2.h>
 #include <bluetoothapis.h>
 
 #include <atomic>
@@ -13,7 +13,8 @@
 
 class BTSerialCommunicationManager : public CommunicationManager {
  public:
-  BTSerialCommunicationManager(std::unique_ptr<EncodingManager> encodingManager, const VRBTSerialConfiguration& configuration);
+  BTSerialCommunicationManager(std::unique_ptr<EncodingManager> encodingManager, VRBTSerialConfiguration configuration,
+                               const VRDeviceConfiguration& deviceConfiguration);
 
  public:
   bool IsConnected();

--- a/include/Communication/CommunicationManager.h
+++ b/include/Communication/CommunicationManager.h
@@ -7,12 +7,13 @@
 #include <string>
 #include <thread>
 
+#include "DeviceConfiguration.h"
 #include "Encode/EncodingManager.h"
 
 class CommunicationManager {
  public:
-  CommunicationManager() : m_encodingManager(nullptr){};
-  CommunicationManager(std::unique_ptr<EncodingManager> encodingManager);
+  CommunicationManager(const VRDeviceConfiguration& deviceConfiguration);
+  CommunicationManager(std::unique_ptr<EncodingManager> encodingManager, const VRDeviceConfiguration& deviceConfiguration);
 
   virtual void BeginListener(const std::function<void(VRInputData)>& callback);
   virtual void Disconnect();
@@ -33,6 +34,7 @@ class CommunicationManager {
 
  protected:
   std::unique_ptr<EncodingManager> m_encodingManager;
+  VRDeviceConfiguration m_deviceConfiguration;
 
   std::atomic<bool> m_threadActive;
   std::thread m_thread;

--- a/include/Communication/NamedPipeCommunicationManager.h
+++ b/include/Communication/NamedPipeCommunicationManager.h
@@ -11,7 +11,7 @@
 class NamedPipeCommunicationManager : public CommunicationManager {
 
  public:
-  NamedPipeCommunicationManager(const VRNamedPipeInputConfiguration& configuration);
+  NamedPipeCommunicationManager(const VRNamedPipeInputConfiguration& configuration, const VRDeviceConfiguration& deviceConfiguration);
   bool IsConnected();
 
  protected:

--- a/include/Communication/SerialCommunicationManager.h
+++ b/include/Communication/SerialCommunicationManager.h
@@ -12,7 +12,7 @@
 
 class SerialCommunicationManager : public CommunicationManager {
  public:
-  SerialCommunicationManager(std::unique_ptr<EncodingManager> encodingManager, const VRSerialConfiguration& configuration);
+  SerialCommunicationManager(std::unique_ptr<EncodingManager> encodingManager, VRSerialConfiguration configuration, const VRDeviceConfiguration& deviceConfiguration);
 
   bool IsConnected();
 

--- a/include/DeviceConfiguration.h
+++ b/include/DeviceConfiguration.h
@@ -46,42 +46,42 @@ struct VRNamedPipeInputConfiguration {
   std::string pipeName;
 
   VRNamedPipeInputConfiguration(std::string pipeName) : pipeName(pipeName){};
-
 };
 
 struct VRPoseConfiguration {
-  VRPoseConfiguration(vr::HmdVector3_t offsetVector, vr::HmdQuaternion_t angleOffsetQuaternion, float poseTimeOffset, bool controllerOverrideEnabled,
-                        int controllerIdOverride, bool calibrationButtonEnabled)
-      : offsetVector(offsetVector),
-        angleOffsetQuaternion(angleOffsetQuaternion),
-        poseTimeOffset(poseTimeOffset),
-        controllerOverrideEnabled(controllerOverrideEnabled),
-        controllerIdOverride(controllerIdOverride),
-        calibrationButtonEnabled(calibrationButtonEnabled){};
   vr::HmdVector3_t offsetVector;
   vr::HmdQuaternion_t angleOffsetQuaternion;
   float poseTimeOffset;
   int controllerIdOverride;
   bool controllerOverrideEnabled;
   bool calibrationButtonEnabled;
+
+  VRPoseConfiguration(const vr::HmdVector3_t offsetVector, const vr::HmdQuaternion_t angleOffsetQuaternion, const float poseTimeOffset,
+                        const bool controllerOverrideEnabled, const int controllerIdOverride, const bool calibrationButtonEnabled)
+      : offsetVector(offsetVector),
+        angleOffsetQuaternion(angleOffsetQuaternion),
+        poseTimeOffset(poseTimeOffset),
+        controllerIdOverride(controllerIdOverride),
+        controllerOverrideEnabled(controllerOverrideEnabled),
+        calibrationButtonEnabled(calibrationButtonEnabled) {}
 };
 
 struct VRDeviceConfiguration {
-  VRDeviceConfiguration(vr::ETrackedControllerRole role, bool enabled, VRPoseConfiguration poseConfiguration, VREncodingProtocol encodingProtocol,
-                          VRCommunicationProtocol communicationProtocol, VRDeviceDriver deviceDriver)
-      : role(role),
-        enabled(enabled),
-        poseConfiguration(poseConfiguration),
-        encodingProtocol(encodingProtocol),
-        communicationProtocol(communicationProtocol),
-        deviceDriver(deviceDriver){};
-
   vr::ETrackedControllerRole role;
   bool enabled;
-
+  bool feedbackEnabled;
   VRPoseConfiguration poseConfiguration;
-
   VREncodingProtocol encodingProtocol;
   VRCommunicationProtocol communicationProtocol;
   VRDeviceDriver deviceDriver;
+
+  VRDeviceConfiguration(const vr::ETrackedControllerRole role, const bool enabled, const bool feedbackEnabled, const VRPoseConfiguration poseConfiguration,
+                          const VREncodingProtocol encodingProtocol, const VRCommunicationProtocol communicationProtocol, const VRDeviceDriver deviceDriver)
+      : role(role),
+        enabled(enabled),
+        feedbackEnabled(feedbackEnabled),
+        poseConfiguration(poseConfiguration),
+        encodingProtocol(encodingProtocol),
+        communicationProtocol(communicationProtocol),
+        deviceDriver(deviceDriver) {}
 };

--- a/openglove/resources/settings/default.vrsettings
+++ b/openglove/resources/settings/default.vrsettings
@@ -1,9 +1,9 @@
 {
-  "driver_openglove":
-  {
+  "driver_openglove": {
     "__title": "OpenGlove Configuration",
     "left_enabled": true,
     "right_enabled": true,
+    "feedback_enabled": true,
     "communication_protocol": 0, //title:Communication Method
     "device_driver": 1, //title:Device Driver Emulation
     "encoding_protocol": 1 //title:Encoding Protocol

--- a/src/Communication/BTSerialCommunicationManager.cpp
+++ b/src/Communication/BTSerialCommunicationManager.cpp
@@ -1,14 +1,17 @@
 #include "Communication/BTSerialCommunicationManager.h"
 
 #include <Windows.h>
-#include <Ws2bth.h>
+#include <ws2bth.h>
+
+#include <utility>
 
 #include "DriverLog.h"
 #include "Util/Logic.h"
 #include "Util/Windows.h"
 
-BTSerialCommunicationManager::BTSerialCommunicationManager(std::unique_ptr<EncodingManager> encodingManager, const VRBTSerialConfiguration& configuration)
-    : CommunicationManager(std::move(encodingManager)), m_btSerialConfiguration(configuration), m_isConnected(false), m_btClientSocket(NULL) {}
+BTSerialCommunicationManager::BTSerialCommunicationManager(std::unique_ptr<EncodingManager> encodingManager, VRBTSerialConfiguration configuration,
+                                                           const VRDeviceConfiguration& deviceConfiguration)
+    : CommunicationManager(std::move(encodingManager), deviceConfiguration), m_btSerialConfiguration(configuration), m_isConnected(false), m_btClientSocket(NULL) {}
 
 bool BTSerialCommunicationManager::IsConnected() { return m_isConnected; }
 
@@ -84,8 +87,8 @@ bool BTSerialCommunicationManager::ConnectToDevice(BTH_ADDR& deviceBtAddress) {
   }
 
   unsigned long nonBlockingMode = 1;
-  if (ioctlsocket(m_btClientSocket, FIONBIO, &nonBlockingMode) != 0)  // set the socket to be non-blocking, meaning
-  {                                                                   // it will return right away when sending/recieving
+  // set the socket to be non-blocking, meaning it will return right away when sending/receiving
+  if (ioctlsocket(m_btClientSocket, FIONBIO, &nonBlockingMode) != 0) {
     LogError("Could not set socket to be non-blocking");
     return false;
   }

--- a/src/Communication/NamedPipeCommunicationManager.cpp
+++ b/src/Communication/NamedPipeCommunicationManager.cpp
@@ -1,6 +1,7 @@
 #include "Communication/NamedPipeCommunicationManager.h"
 
-NamedPipeCommunicationManager::NamedPipeCommunicationManager(const VRNamedPipeInputConfiguration& configuration) : m_configuration(configuration), m_isConnected(false){};
+NamedPipeCommunicationManager::NamedPipeCommunicationManager(const VRNamedPipeInputConfiguration& configuration, const VRDeviceConfiguration& deviceConfiguration)
+    : CommunicationManager(deviceConfiguration), m_configuration(configuration), m_isConnected(false){};
 
 bool NamedPipeCommunicationManager::Connect() {
   m_namedPipeListener = std::make_unique<NamedPipeListener<VRInputData>>(m_configuration.pipeName);


### PR DESCRIPTION
* Input throttling and configurable feedback

If the glove firmware sends data more often than we poll for it then the buffer will become saturated and block future reads. Data is guaranteed to be ready on the next read so just purge the buffers after we get a full set of encoded data.

Added config to enable/disable feedback for gloves that do not support it.

* Revert formatting